### PR TITLE
Fix for Ved 1.9.0-pre39 changes

### DIFF
--- a/sourceedits.lua
+++ b/sourceedits.lua
@@ -31,6 +31,9 @@ sourceedits =
 		luapattern = false,
 		allowmultiple = false,
         },
+	},
+	["tool_mousedown"] =
+	{
 		{
 		find = [[
 		elseif love.mouse.isDown("l") and not mousepressed then


### PR DESCRIPTION
Tool handling was moved out of `uis/maineditor/draw.lua` into `tool_mousedown.lua`.